### PR TITLE
Tracking init progress in library store

### DIFF
--- a/zk-states-playground/src/CustomComponentLib.tsx
+++ b/zk-states-playground/src/CustomComponentLib.tsx
@@ -21,6 +21,7 @@ const {
   useInitZKStore,
   useProof,
   useIsInitialized,
+  useInitializationProgress,
   useQueuedAssertions,
   useIsProving,
   useProofFailed,
@@ -48,12 +49,13 @@ const CustomComponentLib = () => {
   const proofFailed = useProofFailed();
   const hasWallet = useHasWallet();
   const { verificationStatus, verify } = useVerify();
+  const initProgress = useInitializationProgress();
 
   useInitZKStore();
 
   if (!hasWallet) return <p>No wallet found</p>;
 
-  if (!isInitialized) return <p>Initializing...</p>;
+  if (!isInitialized) return <p>{initProgress}</p>;
 
   return (
     <div>
@@ -71,6 +73,7 @@ const CustomComponentLib = () => {
       {proof && <p>{proof.proof}</p>}
 
       <p>Verification status: {verificationStatus}</p>
+      <p>Initialization progress: {initProgress}</p>
       <button
         disabled={verificationStatus === "pending" || asssertions.length > 0}
         onClick={() => void verify()}

--- a/zk-states/src/hooks.ts
+++ b/zk-states/src/hooks.ts
@@ -56,6 +56,9 @@ export const createZKState = <T extends object>(
     const resetQueue = useLibStore((state) => state.resetQueue);
     const setProofFailed = useLibStore((state) => state.setProofFailed);
     const setHasWallet = useLibStore((state) => state.setHasWallet);
+    const setInitializationProgress = useLibStore(
+      (state) => state.setInitializationProgress,
+    );
 
     const rollback = useZKStore((state) => state.rollback);
 
@@ -117,6 +120,10 @@ export const createZKState = <T extends object>(
                 setProofFailed(false);
                 break;
               }
+              case "initializationProgress": {
+                setInitializationProgress(workerRes.status);
+                break;
+              }
             }
           },
         );
@@ -127,6 +134,7 @@ export const createZKState = <T extends object>(
     }, [
       initLibStore,
       isInitialized,
+      setInitializationProgress,
       resetQueue,
       rollback,
       setHasWallet,
@@ -176,6 +184,8 @@ export const createZKState = <T extends object>(
     useLibStore((state) => state.queuedAssertions);
   const useIsProving = () => useLibStore((state) => state.isProving);
   const useProofFailed = () => useLibStore((state) => state.proofFailed);
+  const useInitializationProgress = () =>
+    useLibStore((state) => state.initializationProgress);
   const useHasWallet = () => useLibStore((state) => state.hasWallet);
 
   return {
@@ -184,6 +194,7 @@ export const createZKState = <T extends object>(
     useProof,
     useIsInitialized,
     useQueuedAssertions,
+    useInitializationProgress,
     useIsProving,
     useProofFailed,
     useVerify,

--- a/zk-states/src/store.ts
+++ b/zk-states/src/store.ts
@@ -1,9 +1,11 @@
 import type { JsonProof, PublicKey } from "o1js";
 import { create } from "zustand";
+import { type initializationProgress } from "./types";
 
 export interface LibStateVars {
   proof?: JsonProof;
   isInitialized: boolean;
+  initializationProgress: initializationProgress;
   isProving: boolean;
   proofFailed: boolean;
   queuedAssertions: string[];
@@ -19,6 +21,7 @@ export interface LibStateActions {
     accountExists: boolean,
   ) => void;
   setProof: (proof: JsonProof) => void;
+  setInitializationProgress: (status: initializationProgress) => void;
   setHasWallet: (hasWallet: boolean) => void;
   setIsProving: (isProving: boolean) => void;
   setQueuedAssertions: (assertions: string[]) => void;
@@ -31,6 +34,7 @@ export type LibState = LibStateVars & LibStateActions;
 export const useLibStore = create<LibState>((set) => ({
   isInitialized: false,
   isProving: false,
+  initializationProgress: "initializing",
   queuedAssertions: [],
   hasBeenReset: false,
   proofFailed: false,
@@ -41,6 +45,8 @@ export const useLibStore = create<LibState>((set) => ({
     set({ proof, userPublicKey, accountExists, isInitialized: true }),
   setHasWallet: (hasWallet) => set({ hasWallet }),
   setProof: (proof) => set({ proof }),
+  setInitializationProgress: (initializationProgress) =>
+    set({ initializationProgress }),
   setIsProving: (isProving) => set({ isProving }),
   setQueuedAssertions: (queuedAssertions) => set({ queuedAssertions }),
   setProofFailed: (proofFailed) => set({ proofFailed }),

--- a/zk-states/src/store.ts
+++ b/zk-states/src/store.ts
@@ -1,11 +1,11 @@
 import type { JsonProof, PublicKey } from "o1js";
 import { create } from "zustand";
-import { type initializationProgress } from "./types";
+import { type InitializationProgress } from "./types";
 
 export interface LibStateVars {
   proof?: JsonProof;
   isInitialized: boolean;
-  initializationProgress: initializationProgress;
+  initializationProgress: InitializationProgress;
   isProving: boolean;
   proofFailed: boolean;
   queuedAssertions: string[];
@@ -21,7 +21,7 @@ export interface LibStateActions {
     accountExists: boolean,
   ) => void;
   setProof: (proof: JsonProof) => void;
-  setInitializationProgress: (status: initializationProgress) => void;
+  setInitializationProgress: (status: InitializationProgress) => void;
   setHasWallet: (hasWallet: boolean) => void;
   setIsProving: (isProving: boolean) => void;
   setQueuedAssertions: (assertions: string[]) => void;
@@ -34,7 +34,7 @@ export type LibState = LibStateVars & LibStateActions;
 export const useLibStore = create<LibState>((set) => ({
   isInitialized: false,
   isProving: false,
-  initializationProgress: "initializing",
+  initializationProgress: "pendingStart",
   queuedAssertions: [],
   hasBeenReset: false,
   proofFailed: false,

--- a/zk-states/src/types.ts
+++ b/zk-states/src/types.ts
@@ -128,8 +128,20 @@ interface ProofSuccessUpdate {
   updateType: "proofSuccess";
   callId: string;
 }
+export type initializationProgress =
+  | "initializing"
+  | "compiling program"
+  | "compiling contract"
+  | "creating initial proof"
+  | "initialization done";
+
+interface inititializationProgressUpdate {
+  updateType: "initializationProgress";
+  status: initializationProgress;
+}
 
 export type WorkerStateUpdate =
+  | inititializationProgressUpdate
   | LatestProofUpdate
   | UpdateQueueUpdate
   | IsProvingUpdate

--- a/zk-states/src/types.ts
+++ b/zk-states/src/types.ts
@@ -128,20 +128,20 @@ interface ProofSuccessUpdate {
   updateType: "proofSuccess";
   callId: string;
 }
-export type initializationProgress =
-  | "initializing"
-  | "compiling program"
-  | "compiling contract"
-  | "creating initial proof"
-  | "initialization done";
+export type InitializationProgress =
+  | "pendingStart"
+  | "compilingProgram"
+  | "compilingContract"
+  | "creatingInitialProof"
+  | "done";
 
-interface inititializationProgressUpdate {
+interface InititializationProgressUpdate {
   updateType: "initializationProgress";
-  status: initializationProgress;
+  status: InitializationProgress;
 }
 
 export type WorkerStateUpdate =
-  | inititializationProgressUpdate
+  | InititializationProgressUpdate
   | LatestProofUpdate
   | UpdateQueueUpdate
   | IsProvingUpdate

--- a/zk-states/src/zkAppWorker.ts
+++ b/zk-states/src/zkAppWorker.ts
@@ -17,7 +17,7 @@ import {
   fetchAccountArgsSchema,
   initArgsSchema,
   setMinaNetworkArgsSchema,
-  initializationProgress,
+  InitializationProgress,
 } from "./types";
 import { logger } from "./utils";
 
@@ -131,13 +131,14 @@ const workerFunctions = {
 
     post({
       updateType: "initializationProgress",
-      status: "compiling program",
+      status: "compilingProgram",
     });
+
     await Assert.compile();
 
     post({
       updateType: "initializationProgress",
-      status: "compiling contract",
+      status: "compilingContract",
     });
 
     await StatesVerifier.compile();
@@ -150,7 +151,7 @@ const workerFunctions = {
 
     post({
       updateType: "initializationProgress",
-      status: "creating initial proof",
+      status: "creatingInitialProof",
     });
 
     const creationProof = await Assert.init();
@@ -158,7 +159,7 @@ const workerFunctions = {
 
     post({
       updateType: "initializationProgress",
-      status: "initialization done",
+      status: "done",
     });
 
     return { proof: creationProof.toJSON() };


### PR DESCRIPTION
Changed the initialisation progress message from a ```console.log()``` to a ui hook called ``` useInitialisationProgress ``` that developers can use to get the current stage of the initialisation. 